### PR TITLE
using moment.js to calculate UTC times

### DIFF
--- a/client/src/pages/search.js
+++ b/client/src/pages/search.js
@@ -116,8 +116,8 @@ class RoomSearch extends Component {
         let endTime = this.state.end;
 
         this.setState({
-            startTime: `${day}T${startTime}:00-06:00`, //day + " " + startTime,
-            endTime: `${day}T${endTime}:00-06:00` //day + " " + endTime
+            startTime: moment(`${day} ${startTime}`),
+            endTime: moment(`${day} ${endTime}`) 
         })
     }
 


### PR DESCRIPTION
I noticed that my overly-simplistic creation of the UTC strings was not taking daylight saving time into account. Now using Moment.js instead of concatenation.